### PR TITLE
Town planner all scenes

### DIFF
--- a/gameSource/EditorScenePage.cpp
+++ b/gameSource/EditorScenePage.cpp
@@ -363,13 +363,16 @@ EditorScenePage::EditorScenePage()
     mNextSceneNumber = 0;
     if( mScenesFolder.isDirectory() ) {
         mNextFile = mScenesFolder.getChildFile( "next.txt" );
+        if ( ! mNextFile->exists() ) {
+            mNextFile->writeToFile( mNextSceneNumber );
+            }
         
 //        mNextSceneNumber = mNextFile->readFileIntContents( 0 );
         File **sceneFiles = mScenesFolder.getChildFiles( &mNextSceneNumber );
 	for (int i = 0; i<mNextSceneNumber; i++) {
-		delete sceneFiles[i];
-	}
-	delete [] sceneFiles;
+            delete sceneFiles[i];
+	    }
+        delete [] sceneFiles;
         }
     
 

--- a/gameSource/EditorScenePage.cpp
+++ b/gameSource/EditorScenePage.cpp
@@ -503,9 +503,6 @@ void EditorScenePage::actionPerformed( GUIComponent *inTarget ) {
 
         writeSceneToFile( mNextSceneNumber );
         
-        mNextSceneNumber++;
-        mNextFile->writeToFile( mNextSceneNumber );
-        
         mDeleteButton.setVisible( true );
         mReplaceButton.setVisible( true );
         mNextSceneButton.setVisible( false );
@@ -3578,6 +3575,9 @@ void EditorScenePage::writeSceneToFile( int inIDToUse ) {
 
     f->writeToFile( contents );
     if( inIDToUse == mNextSceneNumber ) {
+        mNextSceneNumber++;
+        mNextFile->writeToFile( mNextSceneNumber );
+        
 	char *fileName = f->getFileName();
 	mSceneID = getSceneFileID( fileName );
 	delete [] fileName;

--- a/gameSource/EditorScenePage.cpp
+++ b/gameSource/EditorScenePage.cpp
@@ -3780,7 +3780,7 @@ char EditorScenePage::tryLoadScene( int inSceneID ) {
             delete [] fileText;
             clearScene();
 
-	    if( numLines > 1 ) {
+	    if( numLines > 1 ) { // One line files obviously aren't real.
 
                 int next = 0;
 
@@ -3788,31 +3788,35 @@ char EditorScenePage::tryLoadScene( int inSceneID ) {
                 int w = mSceneW;
                 int h = mSceneH;
 
-		if( next >= numLines ) {  return r; }
-                sscanf( lines[next], "w=%d", &w );
-                next++;
-		if( next >= numLines ) {  return r; }
-                sscanf( lines[next], "h=%d", &h );
-                next++;
+		if( next < numLines ) { // if we ever look at lines[next] after running out of lines
+                    sscanf( lines[next], "w=%d", &w );    // we will have a segfault.
+                    next++;
+                    }
+
+		if( next < numLines ) {
+                    sscanf( lines[next], "h=%d", &h );
+                    next++;
+                    }
 
                 if( w != mSceneW || h != mSceneH ) {
                     resizeGrid( h, w );
                     }
 
-		if( next >= numLines ) {  return r; }
-                if( strstr( lines[next], "origin" ) != NULL ) {
-                    sscanf( lines[next], "origin=%d,%d", &mZeroX, &mZeroY );
-                    next++;
+		if( next < numLines ) {
+                    if( strstr( lines[next], "origin" ) != NULL ) {
+                        sscanf( lines[next], "origin=%d,%d", &mZeroX, &mZeroY );
+                        next++;
+                        }
                     }
-
                 char floorPresent = false;
                 
-		if( next >= numLines ) {  return r; }
-                if( strstr( lines[next], "floorPresent" ) != NULL ) {
-                    floorPresent = true;
-                    next++;
-                    }
+		if( next < numLines ) {
+                    if( strstr( lines[next], "floorPresent" ) != NULL ) {
+                        floorPresent = true;
+                        next++;
+                        }
 
+		    }
                 clearScene();
                 
                 int numRead = 0;
@@ -3829,7 +3833,7 @@ char EditorScenePage::tryLoadScene( int inSceneID ) {
                     SceneCell *p = &( mPersonCells[y][x] );
                     SceneCell *f = &( mFloorCells[y][x] );
 
-                    next = scanCell( lines, next, c );
+                    next = scanCell( lines, next, c ); // TODO: Keep scanCell from segfaulting when the file was interrupted midstream.
                     next = scanCell( lines, next, p );
 
                     if( floorPresent ) {

--- a/gameSource/EditorScenePage.cpp
+++ b/gameSource/EditorScenePage.cpp
@@ -616,7 +616,7 @@ void EditorScenePage::actionPerformed( GUIComponent *inTarget ) {
             jump *= 5;
             }
         
-        if( mSceneID == -1 ) {
+        if( mSceneID < 0 ) {
             mSceneID = mNextSceneNumber;
             }
         mSceneID -= jump;

--- a/gameSource/EditorScenePage.cpp
+++ b/gameSource/EditorScenePage.cpp
@@ -370,7 +370,6 @@ EditorScenePage::EditorScenePage()
 		delete sceneFiles[i];
 	}
 	delete [] sceneFiles;
-	mNextSceneNumber--;
         }
     
 
@@ -621,8 +620,8 @@ void EditorScenePage::actionPerformed( GUIComponent *inTarget ) {
             mSceneID = mNextSceneNumber;
             }
         mSceneID -= jump;
-        while( mSceneID >= 0 &&
-               ! tryLoadScene( mSceneID ) ) {
+        while( ! tryLoadScene( mSceneID ) &&
+	       mSceneID > 0 ) {
             mSceneID--;
             }
         mReplaceButton.setVisible( true );
@@ -3857,7 +3856,7 @@ void EditorScenePage::checkNextPrevVisible() {
     if( mSceneID == -1 ) {
         mNextSceneButton.setVisible( false );
         
-        mPrevSceneButton.setVisible( num > 1 );        
+        mPrevSceneButton.setVisible( num >= 1 );
         }
     else {
 	if( mSceneID < num - 1 ) {

--- a/gameSource/EditorScenePage.cpp
+++ b/gameSource/EditorScenePage.cpp
@@ -3377,21 +3377,30 @@ File *EditorScenePage::getSceneFile( int inSceneID ) {
 // char *name = autoSprintf( "%d.txt", inSceneID );
     int numFiles = -1;
     File **SceneDirectoryList = mScenesFolder.getChildFilesSorted(&numFiles);
-    if ( inSceneID >= numFiles ) {
-        return NULL;
+    File *f = NULL;
+    if ( inSceneID >= numFiles || inSceneID < 0 ) {
+        do {
+            char *name = autoSprintf( "Editor_%d.txt", inSceneID );
+            f = mScenesFolder.getChildFile( name );
+            inSceneID++;
+            delete [] name;
+            } while ( f->exists() );
+        }
+    else {
+
+        char *name = SceneDirectoryList[inSceneID]->getFileName();
+
+        f = mScenesFolder.getChildFile( name );
+        delete [] name;
         }
 
-    char *name = SceneDirectoryList[inSceneID]->getFileName();
-
-    File *f = mScenesFolder.getChildFile( name );
-    delete [] name;
     for ( int i=0; i<numFiles; i++) {
         delete SceneDirectoryList[i];
         }
 
     delete [] SceneDirectoryList;
     return f;
-    }
+}
 
 
 

--- a/gameSource/EditorScenePage.cpp
+++ b/gameSource/EditorScenePage.cpp
@@ -3380,8 +3380,8 @@ int EditorScenePage::getSceneFileID( char *fileName ) {
 	if ( strcmp(thisFileName, fileName) == 0 ) {
 	    ret = i; // Found it!
 	    }
+	    delete [] thisFileName;
         }
-	delete [] thisFileName;
 
     for( int i = 0; i < numFiles; i++ ) {
         delete SceneDirectoryList[i];

--- a/gameSource/EditorScenePage.cpp
+++ b/gameSource/EditorScenePage.cpp
@@ -363,12 +363,12 @@ EditorScenePage::EditorScenePage()
     mNextSceneNumber = 0;
     if( mScenesFolder.isDirectory() ) {
         mNextFile = mScenesFolder.getChildFile( "next.txt" );
-        if ( ! mNextFile->exists() ) {
+        if ( ! mNextFile->exists() ) { // It might change the scene order, and will change the count, when it's created.
             mNextFile->writeToFile( mNextSceneNumber );
             }
         
 //        mNextSceneNumber = mNextFile->readFileIntContents( 0 );
-        File **sceneFiles = mScenesFolder.getChildFiles( &mNextSceneNumber );
+        File **sceneFiles = mScenesFolder.getChildFiles( &mNextSceneNumber ); // Get the number of scenes we have.
 	for (int i = 0; i<mNextSceneNumber; i++) {
             delete sceneFiles[i];
 	    }
@@ -597,7 +597,7 @@ void EditorScenePage::actionPerformed( GUIComponent *inTarget ) {
         mSceneID += jump;
         while( ! tryLoadScene( mSceneID) &&
 		mSceneID < mNextSceneNumber
-               ) {
+               ) { // Try to load the scene while we're still in bounds.
             mSceneID++;
             }
         mReplaceButton.setVisible( true );
@@ -620,7 +620,7 @@ void EditorScenePage::actionPerformed( GUIComponent *inTarget ) {
             }
         mSceneID -= jump;
         while( ! tryLoadScene( mSceneID ) &&
-	       mSceneID > 0 ) {
+	       mSceneID > 0 ) { // Try to load the scene while we're still in bounds.
             mSceneID--;
             }
         mReplaceButton.setVisible( true );
@@ -2312,7 +2312,7 @@ void EditorScenePage::drawUnderComponents( doublePair inViewCenter,
 			drawOutlineString( s, pos, alignCenter );
 			delete [] s;
 		} else {
-			if (mapChanged) {
+			if (mapChanged) { // Output the current scene filename to the screen.
 				File *f = getSceneFile( mSceneID );
 				char *n = f->getFileName();
 				char *s = autoSprintf( "Scene %s*", n );
@@ -3371,20 +3371,22 @@ void EditorScenePage::specialKeyDown( int inKeyCode ) {
 
 
 int EditorScenePage::getSceneFileID( char *fileName ) {
-    int numFiles = -1;
+    int numFiles = -1; // We want a number that getSceneFile will return this file for.
     File **SceneDirectoryList = mScenesFolder.getChildFilesSorted(&numFiles);
     int ret = -1;
 
     for( int i = 0; i < numFiles && ret == -1; i++) {
 	char *thisFileName = SceneDirectoryList[i]->getFileName();
 	if ( strcmp(thisFileName, fileName) == 0 ) {
-	    ret = i;
+	    ret = i; // Found it!
 	    }
 	    delete [] thisFileName;
         }
+
     for( int i = 0; i < numFiles; i++ ) {
         delete SceneDirectoryList[i];
         }
+
     delete [] SceneDirectoryList;
     return ret;
 }
@@ -3393,16 +3395,16 @@ File *EditorScenePage::getSceneFile( int inSceneID ) {
 // char *name = autoSprintf( "%d.txt", inSceneID );
     int numFiles = -1;
     File **SceneDirectoryList = mScenesFolder.getChildFilesSorted(&numFiles);
-    File *f = NULL;
+    File *f = NULL; // get a sorted list of all files
     if ( inSceneID >= numFiles || inSceneID < 0 ) {
-        do {
+        do { // If we're not in the bounds of that list, we want a NEW file.
             char *name = autoSprintf( "Editor_%d.txt", inSceneID );
             f = mScenesFolder.getChildFile( name );
             inSceneID++;
             delete [] name;
-            } while ( f->exists() );
+            } while ( f->exists() ); // For real though, a new file.
         }
-    else {
+    else { // We want the inSceneID'th file in the directory.
 
         char *name = SceneDirectoryList[inSceneID]->getFileName();
 
@@ -3578,10 +3580,10 @@ void EditorScenePage::writeSceneToFile( int inIDToUse ) {
 
     f->writeToFile( contents );
     if( inIDToUse == mNextSceneNumber ) {
-        mNextSceneNumber++;
+        mNextSceneNumber++; // Just in case we've deleted it. It might change the ID when it's created.
         mNextFile->writeToFile( mNextSceneNumber );
-        
-	char *fileName = f->getFileName();
+
+	char *fileName = f->getFileName(); // Make sure we have the same file we just created loaded.
 	mSceneID = getSceneFileID( fileName );
 	delete [] fileName;
     }
@@ -3778,7 +3780,7 @@ char EditorScenePage::tryLoadScene( int inSceneID ) {
             
             char **lines = split( fileText, "\n", &numLines );
             delete [] fileText;
-            clearScene();
+            clearScene(); // If we fail to load a scene, we're still on a new ID, so clear it.
 
 	    if( numLines > 1 ) { // One line files obviously aren't real.
 
@@ -3818,7 +3820,7 @@ char EditorScenePage::tryLoadScene( int inSceneID ) {
 
 		    }
                 clearScene();
-                
+
                 int numRead = 0;
                 
                 int x, y;
@@ -3883,12 +3885,12 @@ void EditorScenePage::checkNextPrevVisible() {
     mPrevSceneButton.setVisible( false );
 
 
-    if( mSceneID == -1 ) {
+    if( mSceneID == -1 ) { // We're on an unsaved scene. We can always look for the latest from here.
         mNextSceneButton.setVisible( false );
         
         mPrevSceneButton.setVisible( num >= 1 );
         }
-    else {
+    else { // Bounds are from 0 to one less than the number of files in the directory.
 	if( mSceneID < num - 1 ) {
 		mNextSceneButton.setVisible( true );
         }

--- a/gameSource/EditorScenePage.cpp
+++ b/gameSource/EditorScenePage.cpp
@@ -3380,8 +3380,8 @@ int EditorScenePage::getSceneFileID( char *fileName ) {
 	if ( strcmp(thisFileName, fileName) == 0 ) {
 	    ret = i; // Found it!
 	    }
-	    delete [] thisFileName;
         }
+	delete [] thisFileName;
 
     for( int i = 0; i < numFiles; i++ ) {
         delete SceneDirectoryList[i];

--- a/gameSource/EditorScenePage.cpp
+++ b/gameSource/EditorScenePage.cpp
@@ -3399,6 +3399,11 @@ File *EditorScenePage::getSceneFile( int inSceneID ) {
     if ( inSceneID >= numFiles || inSceneID < 0 ) {
         do { // If we're not in the bounds of that list, we want a NEW file.
             char *name = autoSprintf( "Editor_%d.txt", inSceneID );
+	    if( f != NULL ) {
+		delete f;
+		f = NULL;
+	        }
+
             f = mScenesFolder.getChildFile( name );
             inSceneID++;
             delete [] name;

--- a/gameSource/EditorScenePage.cpp
+++ b/gameSource/EditorScenePage.cpp
@@ -3877,6 +3877,7 @@ char EditorScenePage::tryLoadScene( int inSceneID ) {
 void EditorScenePage::checkNextPrevVisible() {
     int num = 0;
     File **cf = mScenesFolder.getChildFiles( &num );
+    mNextSceneNumber = num; // Keep mNextSceneNumber out of bounds, so new files will be new.
         
     mNextSceneButton.setVisible( false );
     mPrevSceneButton.setVisible( false );

--- a/gameSource/EditorScenePage.cpp
+++ b/gameSource/EditorScenePage.cpp
@@ -502,7 +502,6 @@ void EditorScenePage::actionPerformed( GUIComponent *inTarget ) {
     else if( inTarget == &mSaveNewButton ) {
 
         writeSceneToFile( mNextSceneNumber );
-        mSceneID = mNextSceneNumber;
         
         mNextSceneNumber++;
         mNextFile->writeToFile( mNextSceneNumber );
@@ -3371,6 +3370,24 @@ void EditorScenePage::specialKeyDown( int inKeyCode ) {
     }
 
 
+int EditorScenePage::getSceneFileID( char *fileName ) {
+    int numFiles = -1;
+    File **SceneDirectoryList = mScenesFolder.getChildFilesSorted(&numFiles);
+    int ret = -1;
+
+    for( int i = 0; i < numFiles && ret == -1; i++) {
+	char *thisFileName = SceneDirectoryList[i]->getFileName();
+	if ( strcmp(thisFileName, fileName) == 0 ) {
+	    ret = i;
+	    }
+	    delete [] thisFileName;
+        }
+    for( int i = 0; i < numFiles; i++ ) {
+        delete SceneDirectoryList[i];
+        }
+    delete [] SceneDirectoryList;
+    return ret;
+}
 
 File *EditorScenePage::getSceneFile( int inSceneID ) {
 // char *name = autoSprintf( "%d.txt", inSceneID );
@@ -3560,6 +3577,11 @@ void EditorScenePage::writeSceneToFile( int inIDToUse ) {
     lines.deallocateStringElements();
 
     f->writeToFile( contents );
+    if( inIDToUse == mNextSceneNumber ) {
+	char *fileName = f->getFileName();
+	mSceneID = getSceneFileID( fileName );
+	delete [] fileName;
+    }
     delete [] contents;
 
     delete f;

--- a/gameSource/EditorScenePage.h
+++ b/gameSource/EditorScenePage.h
@@ -256,6 +256,7 @@ class EditorScenePage : public GamePage, public ActionListener {
 
         void restartAllMoves();
         
+        int getSceneFileID( char *fileName );
 
         File *getSceneFile( int inSceneID );
         


### PR DESCRIPTION
Allows every file in scenes to be viewed, if available. Handles failure for obviously false files, e.g. next.txt. Still susceptible to scenes cut off halfway through a tile.

Continues to use inSceneID logic, but uses the sorted list of files in the folder to determine bounds and order. Tested to work with tutorial, auto, and seeded scenes, as well as observant button mashing in the editor.

Drawback: Once more than 10 files are created, they no longer will appear in order, due to string sorting. 10 comes before 2, etc. All are still accessible however, and seeded scenes are unaffected.