### PR TITLE
Remove display of race in players in range panel

### DIFF
--- a/gameSource/hetuwmod.cpp
+++ b/gameSource/hetuwmod.cpp
@@ -4656,7 +4656,7 @@ void HetuwMod::drawPlayersInRangePanel() {
 		if (mouseX >= recStartX && mouseX <= recEndX) {
 			if (mouseY >= recStartY && mouseY <= recEndY) {
 				doublePair descDrawPos = { (double)mouseX, (double)mouseY };
-				sprintf( text, "%s GEN:%i", fam->raceName.c_str(), fam->generation);
+				sprintf( text, "%s GEN:%i", fam->generation);
 				float rgba[4];
 				getLastNameColor(fam->name, rgba);
 				drawTextWithBckgr(descDrawPos, text, rgba);

--- a/gameSource/hetuwmod.cpp
+++ b/gameSource/hetuwmod.cpp
@@ -679,11 +679,20 @@ bool HetuwMod::strContainsDangerousAnimal(const char* str) {
 	if (strstr( str, "Shot Domestic Boar with Piglet") != NULL) return false;
 	if (strstr( str, "Shot Wild Boar with Piglet") != NULL) return false;
 	if (strstr( str, "Dead Grizzly Bear") != NULL) return false;
+	if (strstr( str, "Wolf Town Top") != NULL) return false;
+	if (strstr( str, "Wolf Town Pants") != NULL) return false;
+	if (strstr( str, "Wolf Flag Roll") != NULL) return false;
+	if (strstr( str, "Grizzly Bear Hat") != NULL) return false;
+	if (strstr( str, "Dead Brown Snake") != NULL) return false;
 
 	if (strstr( str, "Grizzly Bear") != NULL) return true;
 	if (strstr( str, "Wild Boar") != NULL) return true;
 	if (strstr( str, "Domestic Boar") != NULL) return true;
 	if (strstr( str, "Wolf") != NULL) return true;
+	if (strstr( str, "Brown Snake") != NULL) return true;
+	if (strstr( str, "Angry Bison") != NULL) return true;
+	if (strstr( str, "Angry Shot Bison") != NULL) return true;
+	if (strstr( str, "Swarm of Angry Bees") != NULL) return true;
 
 	return false;
 }

--- a/gameSource/hetuwmod.cpp
+++ b/gameSource/hetuwmod.cpp
@@ -4647,7 +4647,7 @@ void HetuwMod::drawPlayersInRangePanel() {
 		if (mouseX >= recStartX && mouseX <= recEndX) {
 			if (mouseY >= recStartY && mouseY <= recEndY) {
 				doublePair descDrawPos = { (double)mouseX, (double)mouseY };
-				sprintf( text, "%s GEN:%i", fam->generation);
+				sprintf( text, "GEN:%i", fam->generation);
 				float rgba[4];
 				getLastNameColor(fam->name, rgba);
 				drawTextWithBckgr(descDrawPos, text, rgba);

--- a/gameSource/hetuwmod.cpp
+++ b/gameSource/hetuwmod.cpp
@@ -4647,7 +4647,7 @@ void HetuwMod::drawPlayersInRangePanel() {
 		if (mouseX >= recStartX && mouseX <= recEndX) {
 			if (mouseY >= recStartY && mouseY <= recEndY) {
 				doublePair descDrawPos = { (double)mouseX, (double)mouseY };
-				sprintf( text, "%s GEN:%i", fam->raceName.c_str(), fam->generation);
+				sprintf( text, "%s GEN:%i", fam->generation);
 				float rgba[4];
 				getLastNameColor(fam->name, rgba);
 				drawTextWithBckgr(descDrawPos, text, rgba);


### PR DESCRIPTION
Race is a removed feature of 2HOL, mixed with the additional families, there's no need to display this information.