### PR TITLE
Add new player display panel for all living family members

### DIFF
--- a/gameSource/hetuwmod.cpp
+++ b/gameSource/hetuwmod.cpp
@@ -3447,7 +3447,7 @@ bool HetuwMod::livingLifeKeyDown(unsigned char inASCII) {
 	}
 	if (!commandKey && isCharKey(inASCII, charKey_ShowPlayersInRange)) {
 		iDrawPlayersInRangePanel++;
-		if (iDrawPlayersInRangePanel >= 3) iDrawPlayersInRangePanel = 0;
+		if (iDrawPlayersInRangePanel >= 4) iDrawPlayersInRangePanel = 0;
 		return true;
 	}
 	if (!commandKey && isCharKey(inASCII, charKey_ShowDeathMessages)) {
@@ -4278,6 +4278,9 @@ void HetuwMod::updatePlayersInRangePanel() {
 				continue;
 		}
 
+		// Players in family only
+		if (iDrawPlayersInRangePanel == 2 && !isRelated(o)) continue;
+
 		playersInRangeNum++;
 
 		ObjectRecord *obj = getObject(o->displayID);
@@ -4708,7 +4711,11 @@ void HetuwMod::drawPlayersInRangePanel() {
 		if (playersInRangeNum < 10) sprintf(text, "PLAYERS IN RANGE:   %d", playersInRangeNum);
 		else if (playersInRangeNum < 100) sprintf(text, "PLAYERS IN RANGE:  %d", playersInRangeNum);
 		else sprintf(text, "PLAYERS IN RANGE: %d", playersInRangeNum);
-	} else {
+	} else if (iDrawPlayersInRangePanel == 2) { 
+		if (playersInRangeNum < 10) sprintf(text, "PLAYERS IN FAMILY:   %d", playersInRangeNum);
+		else if (playersInRangeNum < 100) sprintf(text, "PLAYERS IN FAMILY:  %d", playersInRangeNum);
+		else sprintf(text, "PLAYERS IN FAMILY: %d", playersInRangeNum);
+	} else if (iDrawPlayersInRangePanel == 3) { 
 		if (playersInRangeNum < 10) sprintf(text, "PLAYERS ON SERVER:   %d", playersInRangeNum);
 		else if (playersInRangeNum < 100) sprintf(text, "PLAYERS ON SERVER:  %d", playersInRangeNum);
 		else sprintf(text, "PLAYERS ON SERVER: %d", playersInRangeNum);


### PR DESCRIPTION
Adds a new panel in addition to the players in range and players on server.
The new panel can be toggled between in the same way as the previous options, but with a new addition.
There is no distance limit on this panel, all living family members are totalled.

New panel:
![Screenshot 2023-07-09 031544](https://github.com/risvh/OneLife-1/assets/20902771/0bb3c303-d170-43e6-b5b0-12abee8b4ed4)

Existing players in range panel: (demonstrating that some players were out of my range)
![Screenshot 2023-07-09 031525](https://github.com/risvh/OneLife-1/assets/20902771/0f9d52fe-6fc1-4556-8086-6bc6e775c85c)

Existing players on server panel: (demonstrating that the new panel includes all players that the old panel did (someone died during screenshots, I'm not doing another))
![Screenshot 2023-07-09 031554](https://github.com/risvh/OneLife-1/assets/20902771/ebf43c7f-ce10-47b6-9be1-74050953be00)
